### PR TITLE
fix: update dangling raw pointer in CompoundTermRefMut::reorder_components

### DIFF
--- a/src/language/features/compound_term.rs
+++ b/src/language/features/compound_term.rs
@@ -753,6 +753,12 @@ impl CompoundTermRefMut<'_> {
         std::mem::swap(&mut placeholder, self.inner.components_mut());
         // * 🚩将替换后名为「占位符」的实际组分进行「重排去重」得到「新组分」
         let new_components = placeholder.sort_dedup();
+        // * 🚩更新悬空指针：在`new_components`被移动赋值之前提前取堆地址
+        // * 📌`Box<[Term]>`的堆内存在移动后不变，所以提前取地址是安全的
+        // * 🐛若不更新，后续调用`components()`将解引用已释放的旧内存 ⇒ segfault
+        if let TermComponents::Compound(ref box_slice) = new_components {
+            self.components = &**box_slice as *const [Term] as *mut [Term];
+        }
         // * 🚩将「新组分」赋值回原先的组分，原先位置上的「占位符」被覆盖
         *self.inner.components_mut() = new_components;
     }


### PR DESCRIPTION
## Summary

`CompoundTermRefMut::reorder_components()` creates a dangling raw pointer by swapping `Box<[Term]>` via `std::mem::swap` without updating `self.components`. This causes SIGSEGV on Linux (glibc) when `components()` is called afterwards.

## Root cause

```rust
pub fn reorder_components(&mut self) {
    let mut placeholder = TermComponents::Empty;
    std::mem::swap(&mut placeholder, self.inner.components_mut());
    // self.components now points to the old Box<[Term]> in `placeholder`
    let new_components = placeholder.sort_dedup(); // new allocation
    *self.inner.components_mut() = new_components;
    // self.components still points to freed memory → DANGLING
}
```

The `self.components` raw pointer (`*mut [Term]`) was created in `as_compound_mut()` and points into the `Box<[Term]>` heap allocation. When `reorder_components` swaps out and replaces the `Box`, the pointer becomes dangling. On Windows MSVC the old memory happened to not be reused yet; on Linux glibc it caused SIGSEGV.

## Fix

Take the heap address of the new `Box<[Term]>` before moving it into `self.inner`:

```rust
let new_components = placeholder.sort_dedup();
if let TermComponents::Compound(ref box_slice) = new_components {
    self.components = &**box_slice as *const [Term] as *mut [Term];
}
*self.inner.components_mut() = new_components;
```

The `Box<[Term]>`'s heap address is stable across the move, so taking the address before the move is safe.

## Reproduction

The crash was found running the law-reasoning benchmark (`全过程v1.nal`, ~500 lines of NAL-4 rules + facts) on Linux x86_64. Windows users are also affected in theory (UB is UB) but the crash was masked by MSVC's allocator behavior.

## Test plan

- [x] Windows: `cargo build --release` succeeds, `全过程v1.nal` runs with 5/5 expected ANSWERs
- [x] Linux (Docker, glibc): same test runs with exit code 0, no segfault